### PR TITLE
modify simple-shell comment to correctly describe behaviour of '&' (ampersand)

### DIFF
--- a/ch3/simple-shell.c
+++ b/ch3/simple-shell.c
@@ -27,7 +27,7 @@ int main(void)
          * After reading user input, the steps are:
          * (1) fork a child process
          * (2) the child process will invoke execvp()
-         * (3) if command included &, parent will invoke wait()
+         * (3) if command did not include &, parent will invoke wait()
          */
     }
     


### PR DESCRIPTION
this modification corrects the description of ampersand behaviour to agree with what the text says. "Unless otherwise specified, the parent process waits for the child to exit before continuing." (OSC9e: p157)
